### PR TITLE
Utilize .NET Standard 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: csharp
+sudo: required
+dist: trusty
+env:
+  - CLI_VERSION=latest
+addons:
+  apt:
+    packages:
+    - gettext
+    - libcurl4-openssl-dev
+    - libicu-dev
+    - libssl-dev
+    - libunwind8
+    - zlib1g
+mono:
+  - 4.4.2
+os:
+  - linux
+  - osx
+osx_image: xcode7.1
+branches:
+  only:
+    - master
+before_install:
+  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fiopenssl; fi
+install:
+  - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
+  - curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
+  - export PATH="$DOTNET_INSTALL_DIR:$PATH"
+script:
+  - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,9 @@ mono:
   - 4.4.2
 os:
   - linux
-  - osx
-osx_image: xcode7.1
 branches:
   only:
     - master
-before_install:
-  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fiopenssl; fi
 install:
   - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
   - curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-Started from frustrations that came out of this StackOverflow post, this is an implementation of the factory pattern that can work with types known at run-time. This does not solve the core problem yet.
+Started from frustrations that came out of [this StackOverflow post](http://stackoverflow.com/questions/39029344/factory-pattern-with-open-generics), this is an implementation of the factory pattern that can work with types known at run-time.
 
-# IFactory
+[![Build status](https://ci.appveyor.com/api/projects/status/26pr0w6y0jw2p3rn/branch/master?svg=true)](https://ci.appveyor.com/project/carusology/invio-extensions-dependencyinjection/branch/master)
+[![NuGet](https://img.shields.io/nuget/v/Invio.Extensions.DependencyInjection.svg)](https://www.nuget.org/packages/Invio.Extensions.DependencyInjection/)
+[![Travis](https://img.shields.io/travis/invio/Invio.Extensions.DependencyInjection.svg?maxAge=3600&label=travis)](https://travis-ci.org/invio/Invio.Extensions.DependencyInjection)
+
+# Factory
 
 - 'implementationFactory' is a factory
 - This formalizes it with a `IFactory` concept

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+version: '{build}'
+pull_requests:
+  do_not_increment_build_number: true
+branches:
+  only:
+  - master
+nuget:
+  disable_publish_on_pr: true
+build_script:
+- ps: .\build.ps1
+test: off
+artifacts:
+- path: .\artifacts\**\*.nupkg
+  name: NuGet
+deploy:
+- provider: NuGet
+  name: production
+  api_key:
+    secure: pQePWXr4TPO2/3nd9MGeyNIFqb1Z7dEpFugbJC9VqjGRpoUMQcuHZPiRzi/anZFl
+  on:
+    branch: master
+    appveyor_repo_tag: true

--- a/build.ps1
+++ b/build.ps1
@@ -62,4 +62,4 @@ $revision = "{0:D4}" -f [convert]::ToInt32($revision, 10)
 
 exec { & dotnet test .\test\Invio.Extensions.DependencyInjection.Tests -c Release }
 
-exec { & dotnet pack .\src\Invio.Extensions.DependencyInjection -c Release -o .\artifacts --version-suffix=$revision }
+exec { & dotnet pack .\src\Invio.Extensions.DependencyInjection -c Release -o .\artifacts }

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,65 @@
+<#
+.SYNOPSIS
+    You can add this to you build script to ensure that psbuild is available before calling
+    Invoke-MSBuild. If psbuild is not available locally it will be downloaded automatically.
+#>
+function EnsurePsbuildInstalled{
+    [cmdletbinding()]
+    param(
+        [string]$psbuildInstallUri = 'https://raw.githubusercontent.com/ligershark/psbuild/master/src/GetPSBuild.ps1'
+    )
+    process{
+        if(-not (Get-Command "Invoke-MsBuild" -errorAction SilentlyContinue)){
+            'Installing psbuild from [{0}]' -f $psbuildInstallUri | Write-Verbose
+            (new-object Net.WebClient).DownloadString($psbuildInstallUri) | iex
+        }
+        else{
+            'psbuild already loaded, skipping download' | Write-Verbose
+        }
+
+        # make sure it's loaded and throw if not
+        if(-not (Get-Command "Invoke-MsBuild" -errorAction SilentlyContinue)){
+            throw ('Unable to install/load psbuild from [{0}]' -f $psbuildInstallUri)
+        }
+    }
+}
+
+# Taken from psake https://github.com/psake/psake
+
+<#
+.SYNOPSIS
+  This is a helper function that runs a scriptblock and checks the PS variable $lastexitcode
+  to see if an error occcured. If an error is detected then an exception is thrown.
+  This function allows you to run command-line programs without having to
+  explicitly check the $lastexitcode variable.
+.EXAMPLE
+  exec { svn info $repository_trunk } "Error executing SVN. Please verify SVN command-line client is installed"
+#>
+function Exec
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=0,Mandatory=1)][scriptblock]$cmd,
+        [Parameter(Position=1,Mandatory=0)][string]$errorMessage = ($msgs.error_bad_command -f $cmd)
+    )
+    & $cmd
+    if ($lastexitcode -ne 0) {
+        throw ("Exec: " + $errorMessage)
+    }
+}
+
+if(Test-Path .\artifacts) { Remove-Item .\artifacts -Force -Recurse }
+
+EnsurePsbuildInstalled
+
+exec { & dotnet restore }
+
+exec { & dotnet build .\src\Invio.Extensions.DependencyInjection }
+exec { & dotnet build .\test\Invio.Extensions.DependencyInjection.Tests }
+
+$revision = @{ $true = $env:APPVEYOR_BUILD_NUMBER; $false = 1 }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
+$revision = "{0:D4}" -f [convert]::ToInt32($revision, 10)
+
+exec { & dotnet test .\test\Invio.Extensions.DependencyInjection.Tests -c Release }
+
+exec { & dotnet pack .\src\Invio.Extensions.DependencyInjection -c Release -o .\artifacts --version-suffix=$revision }

--- a/build.sh
+++ b/build.sh
@@ -26,4 +26,4 @@ mono \
 revision=${TRAVIS_JOB_ID:=1}
 revision=$(printf "%04d" $revision)
 
-dotnet pack ./src/Invio.Extensions.DependencyInjection -c Release -o ./artifacts --version-suffix=$revision
+dotnet pack ./src/Invio.Extensions.DependencyInjection -c Release -o ./artifacts

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+#exit if any command fails
+set -e
+
+artifactsFolder="./artifacts"
+
+if [ -d $artifactsFolder ]; then
+  rm -R $artifactsFolder
+fi
+
+dotnet restore
+
+# Ideally we would use the 'dotnet test' command to test netcoreapp and net46 so restrict for now
+# but this currently doesn't work due to https://github.com/dotnet/cli/issues/3073 so restrict to netcoreapp
+
+dotnet test ./test/Invio.Extensions.DependencyInjection.Tests -c Release -f netcoreapp1.0
+
+# Instead, run directly with mono for the full .net version
+dotnet build ./test/Invio.Extensions.DependencyInjection.Tests -c Release -f net46
+
+mono \
+./test/Invio.Extensions.DependencyInjection.Tests/bin/Release/net46/*/dotnet-test-xunit.exe \
+./test/Invio.Extensions.DependencyInjection.Tests/bin/Release/net46/*/Invio.Extensions.DependencyInjection.Tests.dll
+
+revision=${TRAVIS_JOB_ID:=1}
+revision=$(printf "%04d" $revision)
+
+dotnet pack ./src/Invio.Extensions.DependencyInjection -c Release -o ./artifacts --version-suffix=$revision

--- a/src/Invio.Extensions.DependencyInjection/project.json
+++ b/src/Invio.Extensions.DependencyInjection/project.json
@@ -27,15 +27,7 @@
   },
 
   "frameworks": {
-    "netcoreapp1.0": {
-      "dependencies": {
-        "Microsoft.NETCore.App": {
-          "type": "platform",
-          "version": "1.0.0"
-        }
-      },
-      "imports": "dnxcore50"
-    }
+    "netstandard1.3": {}
   }
 
 }

--- a/test/Invio.Extensions.DependencyInjection.Tests/project.json
+++ b/test/Invio.Extensions.DependencyInjection.Tests/project.json
@@ -3,15 +3,16 @@
 
   "buildOptions": {
     "debugType": "portable",
-    "preserveCompilationContext": true
   },
 
   "dependencies": {
-    "Invio.Extensions.DependencyInjection": "0.1.1",
+    "Invio.Extensions.DependencyInjection": {
+      "version": "0.1.1",
+      "target": "project"
+    },
     "Microsoft.Extensions.DependencyInjection": "1.0.0",
     "dotnet-test-xunit": "2.2.0-*",
-    "xunit": "2.2.0-*",
-    "Moq": "4.6.36-alpha"
+    "xunit": "2.2.0-*"
   },
 
   "testRunner": "xunit",
@@ -28,6 +29,8 @@
         "dotnet5.4",
         "portable-net451+win8"
       ]
-    }
+    },
+    "net46": {}
   }
+
 }


### PR DESCRIPTION
Change the project to utilize .NET Standard 1.3 for cross platform support. Add Appveyor & Travis CI build engines to guarantee tests are ran before code is merged.
