### PR TITLE
Add OpenCover => coveralls.io Code Coverage to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,4 @@ _Pvt_Extensions
 # Code Coverage
 tools/
 opencover_results.xml
+**/project.json.bak

--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,7 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# Code Coverage
+tools/
+opencover_results.xml

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Appveyor](https://ci.appveyor.com/api/projects/status/26pr0w6y0jw2p3rn/branch/master?svg=true)](https://ci.appveyor.com/project/carusology/invio-extensions-dependencyinjection/branch/master)
 [![Travis CI](https://img.shields.io/travis/invio/Invio.Extensions.DependencyInjection.svg?maxAge=3600&label=travis)](https://travis-ci.org/invio/Invio.Extensions.DependencyInjection)
 [![NuGet](https://img.shields.io/nuget/v/Invio.Extensions.DependencyInjection.svg)](https://www.nuget.org/packages/Invio.Extensions.DependencyInjection/)
+[![Coverage](https://coveralls.io/repos/github/invio/Invio.Extensions.DependencyInjection/badge.svg)](https://coveralls.io/github/invio/Invio.Extensions.DependencyInjection)
 
 This library implements the [factory pattern](https://en.wikipedia.org/wiki/Factory_\(object-oriented\_programming\)) as extension methods to [Microsoft's ASP.NET Core Dependency Injection library](https://docs.asp.net/en/latest/fundamentals/dependency-injection.html). It is [.NET Standard 1.3](https://docs.microsoft.com/en-us/dotnet/articles/standard/library) compliant for cross-platform use.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ nuget:
 build_script:
 - ps: .\build.ps1
 after_build:
+- ps: .\set-debug-type.ps1
 - ps: .\coverage.ps1
 test: off
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,9 @@
 version: '{build}'
 pull_requests:
   do_not_increment_build_number: true
+environment:
+  COVERALLS_REPO_TOKEN:
+    secure: VKKZq+pSf9fBNQBKgWmf8WMo4AjrXtoBqDLDjNVnY5eW+V+sZkudTapFbs/B2eXf
 branches:
   only:
   - master
@@ -8,6 +11,8 @@ nuget:
   disable_publish_on_pr: true
 build_script:
 - ps: .\build.ps1
+after_build:
+- ps: .\coverage.ps1
 test: off
 artifacts:
 - path: .\artifacts\**\*.nupkg

--- a/coverage.ps1
+++ b/coverage.ps1
@@ -1,0 +1,6 @@
+nuget install OpenCover -Version 4.6.519 -OutputDirectory tools
+nuget install coveralls.net -Version 0.7.0 -OutputDirectory tools
+
+.\tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:" test ""test\Invio.Extensions.DependencyInjection.Tests\project.json"" -f net46" -register:user -filter:"+[*]* -[xunit*]*" -returntargetcode -output:opencover_results.xml
+
+.\tools\coveralls.net.0.7.0\tools\csmacnz.Coveralls.exe --opencover -i .\opencover_results.xml

--- a/set-debug-type.ps1
+++ b/set-debug-type.ps1
@@ -1,0 +1,4 @@
+copy 'src\Invio.Extensions.DependencyInjection\project.json' 'src\Invio.Extensions.DependencyInjection\project.json.bak'
+$project = Get-Content 'src\Invio.Extensions.DependencyInjection\project.json.bak' -raw | ConvertFrom-Json
+$project.buildOptions.debugType = "full"
+$project | ConvertTo-Json  | set-content 'src\Invio.Extensions.DependencyInjection\project.json'

--- a/src/Invio.Extensions.DependencyInjection/project.json
+++ b/src/Invio.Extensions.DependencyInjection/project.json
@@ -5,7 +5,7 @@
   "authors": [ "Brian Caruso <brian@invioinc.com>" ],
 
   "buildOptions": {
-    "debugType": "portable"
+    "debugType": "full"
   },
 
   "packOptions": {

--- a/src/Invio.Extensions.DependencyInjection/project.json
+++ b/src/Invio.Extensions.DependencyInjection/project.json
@@ -5,7 +5,7 @@
   "authors": [ "Brian Caruso <brian@invioinc.com>" ],
 
   "buildOptions": {
-    "debugType": "full"
+    "debugType": "portable"
   },
 
   "packOptions": {


### PR DESCRIPTION
Still use Travis CI & Appveyor as before, but mutate project.json file and run OpenCover to generate a report, then pass that report to coveralls.io
