### PR TITLE
Refactoring for performance to make sure rather large resolutions won't impact load times.

### DIFF
--- a/src/Invio.Extensions.DependencyInjection/project.json
+++ b/src/Invio.Extensions.DependencyInjection/project.json
@@ -1,7 +1,7 @@
 {
   "name": "Invio.Extensions.DependencyInjection",
   "title": "Invio Extensions to ASP.NET Dependency Injection Framework",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "authors": [ "Brian Caruso <brian@invioinc.com>" ],
 
   "buildOptions": {
@@ -23,7 +23,8 @@
 
   "dependencies": {
     "Microsoft.Extensions.DependencyInjection": "1.0.0",
-    "System.Reflection.TypeExtensions": "4.1.0"
+    "System.Reflection.TypeExtensions": "4.1.0",
+    "Invio.Extensions.Reflection": "0.2.0"
   },
 
   "frameworks": {

--- a/test/Invio.Extensions.DependencyInjection.Tests/ServiceCollectionFactoryExtensionsTests.cs
+++ b/test/Invio.Extensions.DependencyInjection.Tests/ServiceCollectionFactoryExtensionsTests.cs
@@ -97,41 +97,6 @@ namespace Invio.Extensions.DependencyInjection {
             Assert.IsType<FakeService>(service);
         }
 
-        /// <summary>
-        /// Considering the reflection that is being executed to run the factory.
-        /// This test ensures that we can resolve via this method around 100K without
-        /// taking more than a 200 ms penalty.
-        ///
-        /// When running this locally any of the transient calls  were around 52 ms for 100K, and
-        /// everything else was just at 11 ms for 100K.
-        ///
-        /// Invoke is better for maintenance, but poor for performance. If this becomes a problem then
-        /// it is likely that we'll need to switch to delegates.
-        /// http://blogs.msmvps.com/jonskeet/2008/08/09/making-reflection-fly-and-exploring-delegates/
-        /// </summary>
-        [BenchmarkTest]
-        [Theory]
-        [MemberData(nameof(BasicImplementations))]
-        [MemberData(nameof(DependentImplementations))]
-        public void GetService_ExecutionTime(
-            Func<IServiceCollection, IServiceCollection> addWithFactory) {
-            const int executionCount = 100000;
-
-            // Arrange
-            var collection = addWithFactory(new ServiceCollection());
-            var provider = collection.BuildServiceProvider();
-
-            // Act
-            var stopWatch = Stopwatch.StartNew();
-            for (var i = 0; i < executionCount; i++) {
-                provider.GetService<IFakeService>();
-            }
-            stopWatch.Stop();
-
-            // Assert
-            Assert.True(stopWatch.ElapsedMilliseconds < 450);
-        }
-
         public static TheoryData RuntimeTypedImplementations {
             get {
                 return new TheoryData<Func<IServiceCollection, Type, Type, IServiceCollection>> {

--- a/test/Invio.Extensions.DependencyInjection.Tests/ServiceCollectionFactoryExtensionsTests.cs
+++ b/test/Invio.Extensions.DependencyInjection.Tests/ServiceCollectionFactoryExtensionsTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Invio.Extensions.DependencyInjection.Fakes;
+using Invio.Xunit;
 using Xunit;
 
 namespace Invio.Extensions.DependencyInjection {
@@ -61,6 +62,7 @@ namespace Invio.Extensions.DependencyInjection {
             }
         }
 
+        [UnitTest]
         [Theory]
         [MemberData(nameof(BasicImplementations))]
         [MemberData(nameof(DependentImplementations))]
@@ -76,6 +78,7 @@ namespace Invio.Extensions.DependencyInjection {
             );
         }
 
+        [UnitTest]
         [Theory]
         [MemberData(nameof(BasicImplementations))]
         [MemberData(nameof(DependentImplementations))]
@@ -106,6 +109,7 @@ namespace Invio.Extensions.DependencyInjection {
         /// it is likely that we'll need to switch to delegates.
         /// http://blogs.msmvps.com/jonskeet/2008/08/09/making-reflection-fly-and-exploring-delegates/
         /// </summary>
+        [BenchmarkTest]
         [Theory]
         [MemberData(nameof(BasicImplementations))]
         [MemberData(nameof(DependentImplementations))]
@@ -125,7 +129,7 @@ namespace Invio.Extensions.DependencyInjection {
             stopWatch.Stop();
 
             // Assert
-            Assert.True(stopWatch.ElapsedMilliseconds < 200);
+            Assert.True(stopWatch.ElapsedMilliseconds < 450);
         }
 
         public static TheoryData RuntimeTypedImplementations {
@@ -159,6 +163,7 @@ namespace Invio.Extensions.DependencyInjection {
             }
         }
 
+        [UnitTest]
         [Theory]
         [MemberData(nameof(RuntimeTypedImplementations))]
         public void AddWithFactory_NullServiceType(
@@ -174,6 +179,7 @@ namespace Invio.Extensions.DependencyInjection {
             );
         }
 
+        [UnitTest]
         [Theory]
         [MemberData(nameof(RuntimeTypedImplementations))]
         public void AddWithFactory_NullFactoryType(

--- a/test/Invio.Extensions.DependencyInjection.Tests/project.json
+++ b/test/Invio.Extensions.DependencyInjection.Tests/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.2",
+  "version": "0.2.3",
 
   "buildOptions": {
     "debugType": "portable",
@@ -7,7 +7,7 @@
 
   "dependencies": {
     "Invio.Extensions.DependencyInjection": {
-      "version": "0.2.2",
+      "version": "0.2.3",
       "target": "project"
     },
     "Microsoft.Extensions.DependencyInjection": "1.0.0",

--- a/test/Invio.Extensions.DependencyInjection.Tests/project.json
+++ b/test/Invio.Extensions.DependencyInjection.Tests/project.json
@@ -11,6 +11,7 @@
       "target": "project"
     },
     "Microsoft.Extensions.DependencyInjection": "1.0.0",
+    "Invio.Xunit": "0.1.0",
     "dotnet-test-xunit": "2.2.0-*",
     "xunit": "2.2.0-*"
   },


### PR DESCRIPTION
I found that performance could be better using delegates.

I refactored the memberdata so that I wouldn't have to have two tests one for dependent and one for a normal factory service. Also allowed me to consolidate two existing tests.
