### PR TITLE
Cleanup repository for CI

### DIFF
--- a/Invio.Extensions.DependencyInjection.sln
+++ b/Invio.Extensions.DependencyInjection.sln
@@ -1,0 +1,56 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{DF798B15-D8DF-4117-9282-AEF42DDE2DB3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Invio.Extensions.DependencyInjection", "src\Invio.Extensions.DependencyInjection\Invio.Extensions.DependencyInjection.csproj", "{3A202718-CEA7-4188-9407-CF56BF35EC94}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{8EB4639A-CDF7-47D9-8987-18CA9FC71B47}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Invio.Extensions.DependencyInjection.Tests", "test\Invio.Extensions.DependencyInjection.Tests\Invio.Extensions.DependencyInjection.Tests.csproj", "{1D08B0A9-FD63-40DF-826D-0703AA2FA541}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3A202718-CEA7-4188-9407-CF56BF35EC94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A202718-CEA7-4188-9407-CF56BF35EC94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A202718-CEA7-4188-9407-CF56BF35EC94}.Debug|x64.ActiveCfg = Debug|x64
+		{3A202718-CEA7-4188-9407-CF56BF35EC94}.Debug|x64.Build.0 = Debug|x64
+		{3A202718-CEA7-4188-9407-CF56BF35EC94}.Debug|x86.ActiveCfg = Debug|x86
+		{3A202718-CEA7-4188-9407-CF56BF35EC94}.Debug|x86.Build.0 = Debug|x86
+		{3A202718-CEA7-4188-9407-CF56BF35EC94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A202718-CEA7-4188-9407-CF56BF35EC94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3A202718-CEA7-4188-9407-CF56BF35EC94}.Release|x64.ActiveCfg = Release|x64
+		{3A202718-CEA7-4188-9407-CF56BF35EC94}.Release|x64.Build.0 = Release|x64
+		{3A202718-CEA7-4188-9407-CF56BF35EC94}.Release|x86.ActiveCfg = Release|x86
+		{3A202718-CEA7-4188-9407-CF56BF35EC94}.Release|x86.Build.0 = Release|x86
+		{1D08B0A9-FD63-40DF-826D-0703AA2FA541}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D08B0A9-FD63-40DF-826D-0703AA2FA541}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D08B0A9-FD63-40DF-826D-0703AA2FA541}.Debug|x64.ActiveCfg = Debug|x64
+		{1D08B0A9-FD63-40DF-826D-0703AA2FA541}.Debug|x64.Build.0 = Debug|x64
+		{1D08B0A9-FD63-40DF-826D-0703AA2FA541}.Debug|x86.ActiveCfg = Debug|x86
+		{1D08B0A9-FD63-40DF-826D-0703AA2FA541}.Debug|x86.Build.0 = Debug|x86
+		{1D08B0A9-FD63-40DF-826D-0703AA2FA541}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D08B0A9-FD63-40DF-826D-0703AA2FA541}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D08B0A9-FD63-40DF-826D-0703AA2FA541}.Release|x64.ActiveCfg = Release|x64
+		{1D08B0A9-FD63-40DF-826D-0703AA2FA541}.Release|x64.Build.0 = Release|x64
+		{1D08B0A9-FD63-40DF-826D-0703AA2FA541}.Release|x86.ActiveCfg = Release|x86
+		{1D08B0A9-FD63-40DF-826D-0703AA2FA541}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{3A202718-CEA7-4188-9407-CF56BF35EC94} = {DF798B15-D8DF-4117-9282-AEF42DDE2DB3}
+		{1D08B0A9-FD63-40DF-826D-0703AA2FA541} = {8EB4639A-CDF7-47D9-8987-18CA9FC71B47}
+	EndGlobalSection
+EndGlobal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ nuget:
 build_script:
 - ps: .\build.ps1
 after_build:
+- ps: .\set-debug-type.ps1
 - ps: .\coverage.ps1
 test: off
 artifacts:

--- a/build.ps1
+++ b/build.ps1
@@ -52,15 +52,12 @@ if(Test-Path .\artifacts) { Remove-Item .\artifacts -Force -Recurse }
 
 EnsurePsbuildInstalled
 
-exec { & dotnet restore .\src\Invio.Extensions.DependencyInjection }
-exec { & dotnet restore .\test\Invio.Extensions.DependencyInjection.Tests }
-
-exec { & dotnet build .\src\Invio.Extensions.DependencyInjection }
-exec { & dotnet build .\test\Invio.Extensions.DependencyInjection.Tests }
+exec { & dotnet restore }
+exec { & dotnet build }
 
 $revision = @{ $true = $env:APPVEYOR_BUILD_NUMBER; $false = 1 }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
 $revision = "{0:D4}" -f [convert]::ToInt32($revision, 10)
 
 exec { & dotnet test .\test\Invio.Extensions.DependencyInjection.Tests\Invio.Extensions.DependencyInjection.Tests.csproj -c Release }
 
-exec { & dotnet pack .\src\Invio.Extensions.DependencyInjection -c Release -o ..\..\artifacts }
+exec { & dotnet pack -c Release -o ..\..\artifacts }

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,8 @@ if [ -d $artifactsFolder ]; then
   rm -R $artifactsFolder
 fi
 
-dotnet restore ./src/Invio.Extensions.DependencyInjection
-dotnet restore ./test/Invio.Extensions.DependencyInjection.Tests
+dotnet restore
 
 dotnet test ./test/Invio.Extensions.DependencyInjection.Tests/Invio.Extensions.DependencyInjection.Tests.csproj -c Release -f netcoreapp1.0
 
-dotnet pack ./src/Invio.Extensions.DependencyInjection -c Release -o ../../artifacts
+dotnet pack -c Release -o ../../artifacts

--- a/set-debug-type.ps1
+++ b/set-debug-type.ps1
@@ -1,0 +1,8 @@
+$projectName = "Invio.Extensions.DependencyInjection"
+
+copy "src\${projectName}\${projectName}.csproj" "src\${projectName}\${projectName}.csproj.bak"
+
+$project = New-Object XML
+$project.Load("${pwd}\src\${projectName}\${projectName}.csproj")
+$project.Project.PropertyGroup.DebugType = "full"
+$project.Save("${pwd}\src\${projectName}\${projectName}.csproj")

--- a/src/Invio.Extensions.DependencyInjection/Invio.Extensions.DependencyInjection.csproj
+++ b/src/Invio.Extensions.DependencyInjection/Invio.Extensions.DependencyInjection.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-    <PackageReference Include="Invio.Extensions.Reflection" Version="1.0.2" />
+    <PackageReference Include="Invio.Extensions.Reflection" Version="1.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Invio.Extensions.DependencyInjection/Invio.Extensions.DependencyInjection.csproj
+++ b/src/Invio.Extensions.DependencyInjection/Invio.Extensions.DependencyInjection.csproj
@@ -5,7 +5,7 @@
     <VersionPrefix>0.2.5</VersionPrefix>
     <Authors>Brian Caruso &lt;brian@invioinc.com&gt;</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <AssemblyName>Invio.Extensions.DependencyInjection</AssemblyName>
     <PackageId>Invio.Extensions.DependencyInjection</PackageId>
     <PackageTags>dependencyinjection;di</PackageTags>

--- a/test/Invio.Extensions.DependencyInjection.Tests/Invio.Extensions.DependencyInjection.Tests.csproj
+++ b/test/Invio.Extensions.DependencyInjection.Tests/Invio.Extensions.DependencyInjection.Tests.csproj
@@ -12,6 +12,7 @@
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
       1.1.1
     </RuntimeFrameworkVersion>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Invio.Xunit" Version="0.1.2" />
+    <PackageReference Include="Invio.Xunit" Version="0.1.3" />
     <PackageReference Include="xunit" Version="2.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes #14 

Improves `dotnet` CLI developer ergonomics
Improves symbol export via `<DebugType>` of `portable`