### PR TITLE
Net Core v2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 sudo: required
-dotnet: 1.0.4
+dotnet: 2.0.3
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ public void ConfigureServices(IServiceCollection services) {
 }
 ```
 
-This lambda works well for trivial dependencies, but what if the creation of `ExampleService` was complex? Perhaps it requires a few dependencies that are defined in your `IServiceProvider` as well as some decisions based upon configuration defined in `appsettings.json` that have been modularized into [Microsoft's Options framework](https://docs.asp.net/en/latest/fundamentals/configuration.html)? It could become unwieldly, like this:
+This lambda works well for trivial dependencies, but what if the creation of `ExampleService` was complex? Perhaps it requires a few dependencies that are defined in your `IServiceProvider` as well as some decisions based upon configuration defined in `appsettings.json` that have been modularized into [Microsoft's Options framework](https://docs.asp.net/en/latest/fundamentals/configuration.html)? It could become unwieldy, like this:
 
 ```csharp
 // Complex implementationFactory example

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,6 @@ fi
 
 dotnet restore
 
-dotnet test ./test/Invio.Extensions.DependencyInjection.Tests/Invio.Extensions.DependencyInjection.Tests.csproj -c Release -f netcoreapp1.0
+dotnet test ./test/Invio.Extensions.DependencyInjection.Tests/Invio.Extensions.DependencyInjection.Tests.csproj -c Release
 
 dotnet pack -c Release -o ../../artifacts

--- a/coverage.ps1
+++ b/coverage.ps1
@@ -1,6 +1,6 @@
 nuget install OpenCover -Version 4.6.519 -OutputDirectory tools
 nuget install coveralls.net -Version 0.7.0 -OutputDirectory tools
 
-.\tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:" test ""test\Invio.Extensions.DependencyInjection.Tests\Invio.Extensions.DependencyInjection.Tests.csproj"" -f netcoreapp1.0" -register:user -filter:"+[Invio.Extensions.DependencyInjection*]* -[xunit*]*" -oldStyle -returntargetcode -output:opencover_results.xml
+.\tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:" test ""test\Invio.Extensions.DependencyInjection.Tests\Invio.Extensions.DependencyInjection.Tests.csproj"" " -register:user -filter:"+[Invio.Extensions.DependencyInjection*]* -[xunit*]*" -oldStyle -returntargetcode -output:opencover_results.xml
 
 .\tools\coveralls.net.0.7.0\tools\csmacnz.Coveralls.exe --opencover -i .\opencover_results.xml

--- a/src/Invio.Extensions.DependencyInjection/Invio.Extensions.DependencyInjection.csproj
+++ b/src/Invio.Extensions.DependencyInjection/Invio.Extensions.DependencyInjection.csproj
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-    <PackageReference Include="Invio.Extensions.Reflection" Version="1.0.3" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
+    <PackageReference Include="Invio.Extensions.Reflection" Version="1.0.4" />
   </ItemGroup>
 
 </Project>

--- a/test/Invio.Extensions.DependencyInjection.Tests/Invio.Extensions.DependencyInjection.Tests.csproj
+++ b/test/Invio.Extensions.DependencyInjection.Tests/Invio.Extensions.DependencyInjection.Tests.csproj
@@ -1,17 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Invio.Extensions.DependencyInjection.Tests</AssemblyName>
     <PackageId>Invio.Extensions.DependencyInjection.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+    <AssetTargetFallback>
       $(PackageTargetFallback);dotnet5.4;portable-net451+win8
-    </PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-      1.1.1
-    </RuntimeFrameworkVersion>
+    </AssetTargetFallback>
+    <RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -20,15 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Invio.Xunit" Version="0.1.3" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Invio.Xunit" Version="0.1.4" />
+    <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This upgrades every dependency and every test to the latest version of everything that is compatible with `netstandard1.3`, while running tests using .NET Core v2. I will release a patch-level version bump of this package with those settings so we can use these updates immediately.

After this pull request, I will upgrade the entire library to target framework `netstandard2.0`, bump it by a major version to 1.0.0, and use [the 2.0.0 version of the `Microsoft.Extensions.DependencyInjection` dependency](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/2.0.0). This new version of `Microsoft.Extensions.DependencyInjection` uses .NET Standard 2.0 - that's why we have to upgrade our library's target framework.