### PR TITLE
Upgrade to .Net Standard v2.0

### DIFF
--- a/src/Invio.Extensions.DependencyInjection/Invio.Extensions.DependencyInjection.csproj
+++ b/src/Invio.Extensions.DependencyInjection/Invio.Extensions.DependencyInjection.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Invio Extensions to ASP.NET Dependency Injection Framework</AssemblyTitle>
     <VersionPrefix>0.2.7</VersionPrefix>
     <Authors>Brian Caruso &lt;brian@invioinc.com&gt;</Authors>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>Invio.Extensions.DependencyInjection</AssemblyName>
     <PackageId>Invio.Extensions.DependencyInjection</PackageId>
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
     <PackageReference Include="Invio.Extensions.Reflection" Version="1.0.4" />
   </ItemGroup>


### PR DESCRIPTION
In order to use the latest version of `Microsoft.Extensions.DependencyInjection` (2.0.0), [we have to upgrade from `netstandard1.3` to `netstandard2.0`](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/2.0.0). If / when this merge request builds successfully, I'll merge it back into master, bump the version of the library to `1.0.0` and release it.